### PR TITLE
bugfix: permission issue and ambiguous platform for python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ $(ARCHIVES_DIR) $(PIP_TARGET) $(NPM_DEST):
 # Install Python packages to target directory
 .PHONY: install
 install: $(PIP_TARGET)
-	pip install -r $(REQUIREMENTS_FILE) -t $(PIP_TARGET)/python --upgrade
+	pip install -r $(REQUIREMENTS_FILE) --platform manylinux2014_x86_64 -t $(PIP_TARGET)/python --only-binary=:all: --upgrade
 
 # Create archive for lambda function code
 .PHONY: lambda

--- a/infra/modules/quiz/iam.tf
+++ b/infra/modules/quiz/iam.tf
@@ -39,6 +39,7 @@ resource "aws_iam_role_policy" "lambda_dynamodb_policy" {
           "dynamodb:UpdateItem",
           "dynamodb:DeleteItem",
           "dynamodb:Scan",
+          "dynamodb:Query"
         ],
         Resource = [
           "${aws_dynamodb_table.corplife-quiz-questions.arn}",


### PR DESCRIPTION
Fixing an issue I did not anticipate. The workflow runner must have ran on amd64 architecture while the lambda function expects x86. Added a flag to pip to be more explicit in targeting x86 architecture.  Furthermore, the lambda exec role was missing Query permission for DynamoDB 🫣